### PR TITLE
remove convert bindings from render

### DIFF
--- a/src/components/FontAwesomeIcon.js
+++ b/src/components/FontAwesomeIcon.js
@@ -7,54 +7,64 @@ const packNames = {
   brands: 'fab',
   light: 'fal',
   regular: 'far',
-  solid: 'fas'
+  solid: 'fas',
 }
+const convertCurry = convert.bind(null, React.createElement)
 
 class FontAwesomeIcon extends React.Component {
-  _prefix () {
+  _prefix() {
     return packNames[this.props.pack] || this.props.pack
   }
 
-  _iconConfig () {
+  _iconConfig() {
     return { prefix: this._prefix(), iconName: this.props.name }
   }
 
-  _classList () {
+  _classList() {
     let classes = {
       'fa-spin': this.props.spin,
       'fa-pulse': this.props.pulse,
       'fa-fw': this.props.fixedWidth,
       'fa-border': this.props.border,
       'fa-li': this.props.listItem,
-      'fa-flip-horizontal': this.props.flip === 'horizontal' || this.props.flip === 'both',
-      'fa-flip-vertical': this.props.flip === 'vertical' || this.props.flip === 'both',
+      'fa-flip-horizontal':
+        this.props.flip === 'horizontal' || this.props.flip === 'both',
+      'fa-flip-vertical':
+        this.props.flip === 'vertical' || this.props.flip === 'both',
       [`fa-${this.props.size}`]: this.props.size !== null,
       [`fa-rotate-${this.props.rotation}`]: this.props.rotation !== null,
-      [`fa-pull-${this.props.pull}`]: this.props.pull !== null
+      [`fa-pull-${this.props.pull}`]: this.props.pull !== null,
     }
 
     return Object.keys(classes)
-      .map(key => classes[key] ? key : null)
+      .map(key => (classes[key] ? key : null))
       .filter(key => key)
   }
 
-  _transformDirectives () {
-    return (typeof this.props.transform === 'string') ? fontawesome.parse.transform(this.props.transform) : this.props.transform
+  _transformDirectives() {
+    return typeof this.props.transform === 'string'
+      ? fontawesome.parse.transform(this.props.transform)
+      : this.props.transform
   }
 
-  render () {
-    const classes = this._classList().length > 0 ? {classes: this._classList()} : {}
-    const transform = this._transformDirectives() ? {transform: this._transformDirectives()} : {}
-    const {abstract} = fontawesome.icon(this.props.iconDefinition || this._iconConfig(), { ...classes, ...transform })
-    const convertCurry = convert.bind(null, React.createElement)
-    
+  render() {
+    const classes =
+      this._classList().length > 0 ? { classes: this._classList() } : {}
+    const transform = this._transformDirectives()
+      ? { transform: this._transformDirectives() }
+      : {}
+    const { abstract } = fontawesome.icon(
+      this.props.iconDefinition || this._iconConfig(),
+      { ...classes, ...transform }
+    )
+
     return convertCurry(abstract[0])
   }
 }
 
 FontAwesomeIcon.propTypes = {
   border: PropTypes.bool,
-  
+
   fixedWidth: PropTypes.bool,
 
   flip: PropTypes.oneOf(['horizontal', 'vertical', 'both']),
@@ -73,11 +83,25 @@ FontAwesomeIcon.propTypes = {
 
   rotation: PropTypes.oneOf([90, 180, 270]),
 
-  size: PropTypes.oneOf(['lg', 'xs', 'sm', '1x', '2x', '3x', '4x', '5x', '6x', '7x', '8x', '9x', '10x']),
+  size: PropTypes.oneOf([
+    'lg',
+    'xs',
+    'sm',
+    '1x',
+    '2x',
+    '3x',
+    '4x',
+    '5x',
+    '6x',
+    '7x',
+    '8x',
+    '9x',
+    '10x',
+  ]),
 
   spin: PropTypes.bool,
 
-  transform: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
+  transform: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
 }
 
 FontAwesomeIcon.defaultProps = {
@@ -93,7 +117,7 @@ FontAwesomeIcon.defaultProps = {
   rotation: null,
   size: null,
   spin: false,
-  transform: null
+  transform: null,
 }
 
 export default FontAwesomeIcon

--- a/src/converter.js
+++ b/src/converter.js
@@ -1,26 +1,30 @@
 import camelCase from 'camelcase'
 
-function capitalize (val) {
-  return val.charAt(0).toUpperCase() + val.slice(1);
+function capitalize(val) {
+  return val.charAt(0).toUpperCase() + val.slice(1)
 }
 
-function styleToObject (style) {
-  return style.split(';')
-    .map(s => s.trim() )
+function styleToObject(style) {
+  return style
+    .split(';')
+    .map(s => s.trim())
     .filter(s => s)
     .reduce((acc, pair) => {
       const i = pair.indexOf(':')
       const prop = camelCase(pair.slice(0, i))
       const value = pair.slice(i + 1).trim()
-      
-      prop.startsWith('webkit') ? acc[capitalize(prop)] = value : acc[prop] = value
-      
+
+      prop.startsWith('webkit')
+        ? (acc[capitalize(prop)] = value)
+        : (acc[prop] = value)
+
       return acc
     }, {})
 }
 
-function convert (createElement, element) {
-  const children = (element.children || []).map(convert.bind(null, createElement))
+function convert(createElement, element) {
+  const convertCurry = convert.bind(null, createElement)
+  const children = (element.children || []).map(convertCurry)
 
   if (element.attributes.hasOwnProperty('class')) {
     element.attributes['className'] = element.attributes['class']


### PR DESCRIPTION
I haven't tested this since I am not sure what is neither the intent nor output of `fontawesome.icon`

But binding functions in render() means that every time the render method is called a new function will be created -> there are possible GC issues