### PR TITLE
fix convert crashing with attributes-less elements

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -22,12 +22,12 @@ function styleToObject (style) {
 function convert (createElement, element) {
   const children = (element.children || []).map(convert.bind(null, createElement))
 
-  if (element.attributes.hasOwnProperty('class')) {
+  if (element.attributes && element.attributes.hasOwnProperty('class')) {
     element.attributes['className'] = element.attributes['class']
     delete element.attributes['class']
   }
 
-  Object.keys(element.attributes).forEach(key => {
+  Object.keys(element.attributes || {}).forEach(key => {
     const val = element.attributes[key]
 
     switch (key) {


### PR DESCRIPTION
When composing an icon [fontawesomejs.makeIconComposition](https://github.com/FortAwesome/Font-Awesome-Pro/blob/master/js/fontawesome.js#L356) creates a ‘def’ element without attributes which crashes convert.

This is a quick-fix as:

- I don’t know the reason of the first substitution as I haven’t seen that `elements` inherit but I don’t have a good view of all the code.
- [vue-fontawesome](https://github.com/FortAwesome/vue-fontawesome/blob/af3d54a80ec9eff5a793b5a29a177da2537af99b/src/converter.js#L30)'s solution is much more elegant (not mutating the element) which would be a better solution if there a no reason to do things like they are done here.

Signed-off-by: Frédéric Miserey <frederic@none.net>