### PR TITLE
Mask instead of compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Power Transforms:
 Composition:
 
 ```javascript
-<FontAwesomeIcon icon="coffee" compose={['far', 'circle']} />
+<FontAwesomeIcon icon="coffee" mask={['far', 'circle']} />
 ```
 
 Symbols:

--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "@fortawesome/fontawesome": ">=0.0.18",
+    "@fortawesome/fontawesome": ">=0.0.22",
     "prop-types": "^15.5.10",
     "react": "^16.0.0"
   },
   "devDependencies": {
-    "@fortawesome/fontawesome": "0.0.20",
+    "@fortawesome/fontawesome": "0.0.22",
     "babel-jest": "^21.0.0",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-preset-es2015": "^6.24.1",

--- a/src/components/FontAwesomeIcon.js
+++ b/src/components/FontAwesomeIcon.js
@@ -46,17 +46,17 @@ function normalizeIconArgs (icon) {
 }
 
 function FontAwesomeIcon (props) {
-  const { icon: iconArgs, compose: composeArgs, symbol, className } = props
+  const { icon: iconArgs, mask: maskArgs, symbol, className } = props
 
   const icon = normalizeIconArgs(iconArgs)
   const classes = objectWithKey('classes', [...classList(props), ...className.split(' ')])
   const transform = objectWithKey('transform', (typeof props.transform === 'string') ? fontawesome.parse.transform(props.transform) : props.transform)
-  const compose = objectWithKey('compose', normalizeIconArgs(composeArgs))
+  const mask = objectWithKey('mask', normalizeIconArgs(maskArgs))
 
   const renderedIcon = fontawesome.icon(icon, {
     ...classes,
     ...transform,
-    ...compose,
+    ...mask,
     symbol
   })
 
@@ -78,7 +78,7 @@ FontAwesomeIcon.propTypes = {
 
   className: PropTypes.string,
 
-  compose: PropTypes.oneOfType([PropTypes.object, PropTypes.array, PropTypes.string]),
+  mask: PropTypes.oneOfType([PropTypes.object, PropTypes.array, PropTypes.string]),
 
   fixedWidth: PropTypes.bool,
 
@@ -108,7 +108,7 @@ FontAwesomeIcon.propTypes = {
 FontAwesomeIcon.defaultProps = {
   border: false,
   className: '',
-  compose: null,
+  mask: null,
   fixedWidth: false,
   flip: null,
   icon: null,

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -174,9 +174,9 @@ describe('using transform', () => {
   })
 })
 
-describe('compose', () => {
+describe('mask', () => {
   test('will add icon', () => {
-    const vm = mount({ icon: faCoffee, compose: faCircle })
+    const vm = mount({ icon: faCoffee, mask: faCircle })
 
     expect(vm.children.length).toBe(2)
     expect(vm.children[1].props.hasOwnProperty('clipPath')).toBeTruthy()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@fortawesome/fontawesome@0.0.20":
-  version "0.0.20"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome/-/fontawesome-0.0.20.tgz#a86f7161fbe3c3ae4210a3fae50c34c78b49402b"
+"@fortawesome/fontawesome@0.0.22":
+  version "0.0.22"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome/-/fontawesome-0.0.22.tgz#ea533f9bb4edb0dd2b4bc2b7c78d1a2aa0319430"
 
 abab@^1.0.3:
   version "1.0.4"


### PR DESCRIPTION
This is in preparation for the next release of the `fontawesome` lib. It renames `compose` to `mask`.