### PR TITLE
Added typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,52 @@
+declare module '@fortawesome/react-fontawesome' {
+  export type FontAwesomeIconMask = Object | any[] | string;
+
+  export type FontAwesomeIconFlip = 'horizontal' | 'vertical' | 'both';
+
+  export type FontAwesomeIconIcon = Object | any[] | string;
+
+  export type FontAwesomeIconPull = 'right' | 'left';
+
+  export type FontAwesomeIconRotation = 90 | 180 | 270;
+
+  export type FontAwesomeIconSize =
+    | 'lg'
+    | 'xs'
+    | 'sm'
+    | '1x'
+    | '2x'
+    | '3x'
+    | '4x'
+    | '5x'
+    | '6x'
+    | '7x'
+    | '8x'
+    | '9x'
+    | '10x';
+
+  export type FontAwesomeIconSymbol = boolean | string;
+
+  export type FontAwesomeIconTransform = string | Object;
+
+  export interface FontAwesomeIconProps {
+    border?: boolean;
+    className?: string;
+    mask?: FontAwesomeIconMask;
+    fixedWidth?: boolean;
+    flip?: FontAwesomeIconFlip;
+    icon?: FontAwesomeIconIcon;
+    listItem?: boolean;
+    pull?: FontAwesomeIconPull;
+    pulse?: boolean;
+    name?: string;
+    rotation?: FontAwesomeIconRotation;
+    size?: FontAwesomeIconSize;
+    spin?: boolean;
+    symbol?: FontAwesomeIconSymbol;
+    transform?: FontAwesomeIconTransform;
+  }
+
+  export default function FontAwesomeIcon(
+    props: FontAwesomeIconProps,
+  ): JSX.Element;
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Official React component for Font Awesome 5",
   "version": "0.0.14",
   "main": "index.js",
+  "typings": "./index.d.ts",
   "homepage": "https://github.com/FortAwesome/react-fontawesome",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related issue: #17 

Note: This is the first time I've created TypeScript definitions, hopefully it's correct. 

Toyed around with making FontAwesomeIconSize, FontAwesomeIconRotation, and FontAwesomeIconFlip enums i.e.

```
export enum IconFlip {
    Horizontal = 'horizontal',
    Vertical = 'vertical',
    Both = 'both',
  }
```

So they can be imported with react-fontawesome and used like so: 
```
import { FontAwesomeIconFlip } from '@fort-awesome/react-fontawesome'
...
<FontAwesomeIcon flip={FontAwesomeIconFlip.Horizontal} />
```

But hey ho. 