### PR TITLE
Create .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+.babelrc


### PR DESCRIPTION
.babelrc is being published to npm right now. Adding an npmignore file lets you ignore files while publishing. 