### PR TITLE
Add display name property

### DIFF
--- a/src/components/FontAwesomeIcon.js
+++ b/src/components/FontAwesomeIcon.js
@@ -76,6 +76,8 @@ function FontAwesomeIcon (props) {
   return convertCurry(abstract[0], extraProps)
 }
 
+FontAwesomeIcon.displayName = 'FontAwesomeIcon'
+
 FontAwesomeIcon.propTypes = {
   border: PropTypes.bool,
 


### PR DESCRIPTION
`import FontAwesomeIcon from '@fortawesome/react-fontawesome';`

As `<FontAwesomeIcon$1 />` is generated instead of `<FontAwesomeIcon />` in the rendered output, I had to spent enough time to make my test cases work.
The solution is to set `displayName` property to `FontAwesomeIcon` so that the rendered output doesn't show `$1`.