### PR TITLE
add tabindex as optional props

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -30,4 +30,5 @@ export interface Props {
   transform?: string | Transform
   symbol?: FaSymbol
   style?: CSSProperties
+  tabindex?: number;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -30,5 +30,5 @@ export interface Props {
   transform?: string | Transform
   symbol?: FaSymbol
   style?: CSSProperties
-  tabindex?: number;
+  tabIndex?: number;
 }


### PR DESCRIPTION
In order to make the icon focusable, we need to enable passing tabindex to the icon as props.