### PR TITLE
Remove humps

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "rollup-plugin-node-resolve": "^3.3.0"
   },
   "dependencies": {
-    "humps": "^2.0.1",
     "prop-types": "^15.5.10"
   },
   "files": [


### PR DESCRIPTION
Rollup should already including humps in the dist files. (index.js and index.es.js)

Fixes #114 