### PR TITLE
Allow specifying prefix and icon name in icon attribute

### DIFF
--- a/src/components/FontAwesomeIcon.js
+++ b/src/components/FontAwesomeIcon.js
@@ -45,6 +45,11 @@ function normalizeIconArgs(icon) {
   }
 
   if (typeof icon === 'string') {
+    const prefixIconRegex = /^[a-z]{3} [a-z0-9-]+$/
+    if (prefixIconRegex.test(icon)) {
+      const [prefix, iconName] = icon.split(' ')
+      return { prefix, iconName }
+    }
     return { prefix: 'fas', iconName: icon }
   }
 }


### PR DESCRIPTION
I thought it would be nice if, instead of specifying the prefix like this ...

```javascript
<FontAwesomeIcon icon={['fab', 'apple']} />
```

... we could instead specify it like this (i.e. more similar to the default-prefixed version) ...

```javascript
<FontAwesomeIcon icon="fab apple" />
```

I didn't add tests, because (a) I wanted to gauge initial feedback to the idea and (b) I don't have a huge amount of time right now to understand how to test this, as it doesn't appear similar to any other test cases.

So ... thoughts? 😄 
