### PR TITLE
Support for prop ref

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,7 @@ import {
 export function FontAwesomeIcon(props: Props): JSX.Element
 
 export interface Props {
+  ref: ((e: any) => void) | React.RefObject<any>
   icon: IconProp
   mask?: IconProp
   className?: string

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,7 @@ import {
 export function FontAwesomeIcon(props: Props): JSX.Element
 
 export interface Props {
-  ref: ((e: any) => void) | React.RefObject<any>
+  ref?: ((e: any) => void) | React.RefObject<any>
   icon: IconProp
   mask?: IconProp
   className?: string

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "peerDependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.0-7",
-    "react": "16.x"
+    "react": ">= 16.3.0"
   },
   "devDependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.0-7",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -31,7 +31,6 @@ export default {
       jsnext: true,
       main: true
     }),
-    commonJs(),
     babel({
       babelrc: false,
       presets: [
@@ -48,6 +47,7 @@ export default {
       ],
       plugins: ['external-helpers'],
       exclude: 'node_modules/**'
-    })
+    }),
+    commonJs()
   ]
 }

--- a/src/components/FontAwesomeIcon.js
+++ b/src/components/FontAwesomeIcon.js
@@ -49,7 +49,7 @@ function normalizeIconArgs(icon) {
   }
 }
 
-export default function FontAwesomeIcon(props) {
+function FontAwesomeIcon({ forwardedRef, ...props }) {
   const { icon: iconArgs, mask: maskArgs, symbol, className, title } = props
 
   const iconLookup = normalizeIconArgs(iconArgs)
@@ -79,7 +79,7 @@ export default function FontAwesomeIcon(props) {
   }
 
   const { abstract } = renderedIcon
-  const extraProps = {}
+  const extraProps = { ref: forwardedRef }
 
   Object.keys(props).forEach(key => {
     if (!FontAwesomeIcon.defaultProps.hasOwnProperty(key)) {
@@ -168,3 +168,7 @@ FontAwesomeIcon.defaultProps = {
 }
 
 const convertCurry = convert.bind(null, React.createElement)
+
+export default React.forwardRef((props, ref) => (
+  <FontAwesomeIcon {...props} forwardedRef={ref} />
+))

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -32,8 +32,10 @@ const faCircle = {
 
 fontawesome.library.add(faCoffee, faCircle)
 
-function mount(props = {}) {
-  const component = renderer.create(<FontAwesomeIcon {...props} />)
+function mount(props = {}, { createNodeMock } = {}) {
+  const component = renderer.create(<FontAwesomeIcon {...props} />, {
+    createNodeMock
+  })
 
   return component.toJSON()
 }
@@ -272,5 +274,36 @@ describe('title', () => {
     const vm = mount({ icon: faCoffee, title: 'Coffee' })
     expect(vm.children[0].type).toBe('title')
     expect(vm.children[0].children[0]).toBe('Coffee')
+  })
+})
+
+describe('using ref', () => {
+  const node = {}
+
+  test('function', () => {
+    const spy = jest.fn(element => element)
+
+    mount(
+      { icon: faCoffee, ref: spy },
+      {
+        createNodeMock: () => node
+      }
+    )
+
+    expect(spy.mock.calls.length).toBe(1)
+    expect(spy.mock.results[0].value).toBe(node)
+  })
+
+  test('createRef', () => {
+    const ref = React.createRef()
+
+    mount(
+      { icon: faCoffee, ref },
+      {
+        createNodeMock: () => node
+      }
+    )
+
+    expect(ref.current).toBe(node)
   })
 })


### PR DESCRIPTION
### Breaking Changes

- React `peerDependencies` changes `16.x` to `>= 16.3.0` (using [React.forwardRef](https://github.com/facebook/react/blob/master/CHANGELOG.md#1630-march-29-2018))

Resolve #199