### PR TITLE
Add DomAttributes to typescript typedefs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@ import {
 
 export function FontAwesomeIcon(props: Props): JSX.Element
 
-export interface Props {
+export interface Props extends React.DOMAttributes<SVGImageElement> {
   icon: IconProp
   mask?: IconProp
   className?: string


### PR DESCRIPTION
This resolves #151 by adding suggested React.DOMAttributes to Props interface.  Allows use of onClick and other properties in typescript.  No test added as it's an addition to type definitions only, ie non functional.