### PR TITLE
Use local camelize function and migrate utility methods to separate modules

### DIFF
--- a/index.es.js
+++ b/index.es.js
@@ -106,143 +106,62 @@ function _nonIterableSpread() {
   throw new TypeError("Invalid attempt to spread non-iterable instance");
 }
 
-var commonjsGlobal = typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {};
+// Get CSS class list from a props object
+function classList(props) {
+  var _classes;
 
-function createCommonjsModule(fn, module) {
-	return module = { exports: {} }, fn(module, module.exports), module.exports;
+  var spin = props.spin,
+      pulse = props.pulse,
+      fixedWidth = props.fixedWidth,
+      inverse = props.inverse,
+      border = props.border,
+      listItem = props.listItem,
+      flip = props.flip,
+      size = props.size,
+      rotation = props.rotation,
+      pull = props.pull; // map of CSS class names to properties
+
+  var classes = (_classes = {
+    'fa-spin': spin,
+    'fa-pulse': pulse,
+    'fa-fw': fixedWidth,
+    'fa-inverse': inverse,
+    'fa-border': border,
+    'fa-li': listItem,
+    'fa-flip-horizontal': flip === 'horizontal' || flip === 'both',
+    'fa-flip-vertical': flip === 'vertical' || flip === 'both'
+  }, _defineProperty(_classes, "fa-".concat(size), typeof size !== 'undefined'), _defineProperty(_classes, "fa-rotate-".concat(rotation), typeof rotation !== 'undefined'), _defineProperty(_classes, "fa-pull-".concat(pull), typeof pull !== 'undefined'), _classes); // map over all the keys in the classes object
+  // return an array of the keys where the value for the key is not null
+
+  return Object.keys(classes).map(function (key) {
+    return classes[key] ? key : null;
+  }).filter(function (key) {
+    return key;
+  });
 }
 
-var humps = createCommonjsModule(function (module) {
-(function(global) {
+// Camelize taken from humps
+// humps is copyright © 2012+ Dom Christie
+// Released under the MIT license.
+// Performant way to determine if object coerces to a number
+function _isNumerical(obj) {
+  obj = obj - 0; // eslint-disable-next-line no-self-compare
 
-  var _processKeys = function(convert, obj, options) {
-    if(!_isObject(obj) || _isDate(obj) || _isRegExp(obj) || _isBoolean(obj) || _isFunction(obj)) {
-      return obj;
-    }
+  return obj === obj;
+}
 
-    var output,
-        i = 0,
-        l = 0;
+function camelize(string) {
+  if (_isNumerical(string)) {
+    return string;
+  } // eslint-disable-next-line no-useless-escape
 
-    if(_isArray(obj)) {
-      output = [];
-      for(l=obj.length; i<l; i++) {
-        output.push(_processKeys(convert, obj[i], options));
-      }
-    }
-    else {
-      output = {};
-      for(var key in obj) {
-        if(Object.prototype.hasOwnProperty.call(obj, key)) {
-          output[convert(key, options)] = _processKeys(convert, obj[key], options);
-        }
-      }
-    }
-    return output;
-  };
 
-  // String conversion methods
+  string = string.replace(/[\-_\s]+(.)?/g, function (match, chr) {
+    return chr ? chr.toUpperCase() : '';
+  }); // Ensure 1st char is always lowercase
 
-  var separateWords = function(string, options) {
-    options = options || {};
-    var separator = options.separator || '_';
-    var split = options.split || /(?=[A-Z])/;
-
-    return string.split(split).join(separator);
-  };
-
-  var camelize = function(string) {
-    if (_isNumerical(string)) {
-      return string;
-    }
-    string = string.replace(/[\-_\s]+(.)?/g, function(match, chr) {
-      return chr ? chr.toUpperCase() : '';
-    });
-    // Ensure 1st char is always lowercase
-    return string.substr(0, 1).toLowerCase() + string.substr(1);
-  };
-
-  var pascalize = function(string) {
-    var camelized = camelize(string);
-    // Ensure 1st char is always uppercase
-    return camelized.substr(0, 1).toUpperCase() + camelized.substr(1);
-  };
-
-  var decamelize = function(string, options) {
-    return separateWords(string, options).toLowerCase();
-  };
-
-  // Utilities
-  // Taken from Underscore.js
-
-  var toString = Object.prototype.toString;
-
-  var _isFunction = function(obj) {
-    return typeof(obj) === 'function';
-  };
-  var _isObject = function(obj) {
-    return obj === Object(obj);
-  };
-  var _isArray = function(obj) {
-    return toString.call(obj) == '[object Array]';
-  };
-  var _isDate = function(obj) {
-    return toString.call(obj) == '[object Date]';
-  };
-  var _isRegExp = function(obj) {
-    return toString.call(obj) == '[object RegExp]';
-  };
-  var _isBoolean = function(obj) {
-    return toString.call(obj) == '[object Boolean]';
-  };
-
-  // Performant way to determine if obj coerces to a number
-  var _isNumerical = function(obj) {
-    obj = obj - 0;
-    return obj === obj;
-  };
-
-  // Sets up function which handles processing keys
-  // allowing the convert function to be modified by a callback
-  var _processor = function(convert, options) {
-    var callback = options && 'process' in options ? options.process : options;
-
-    if(typeof(callback) !== 'function') {
-      return convert;
-    }
-
-    return function(string, options) {
-      return callback(string, convert, options);
-    }
-  };
-
-  var humps = {
-    camelize: camelize,
-    decamelize: decamelize,
-    pascalize: pascalize,
-    depascalize: decamelize,
-    camelizeKeys: function(object, options) {
-      return _processKeys(_processor(camelize, options), object);
-    },
-    decamelizeKeys: function(object, options) {
-      return _processKeys(_processor(decamelize, options), object, options);
-    },
-    pascalizeKeys: function(object, options) {
-      return _processKeys(_processor(pascalize, options), object);
-    },
-    depascalizeKeys: function () {
-      return this.decamelizeKeys.apply(this, arguments);
-    }
-  };
-
-  if (module.exports) {
-    module.exports = humps;
-  } else {
-    global.humps = humps;
-  }
-
-})(commonjsGlobal);
-});
+  return string.substr(0, 1).toLowerCase() + string.substr(1);
+}
 
 function capitalize(val) {
   return val.charAt(0).toUpperCase() + val.slice(1);
@@ -255,7 +174,7 @@ function styleToObject(style) {
     return s;
   }).reduce(function (acc, pair) {
     var i = pair.indexOf(':');
-    var prop = humps.camelize(pair.slice(0, i));
+    var prop = camelize(pair.slice(0, i));
     var value = pair.slice(i + 1).trim();
     prop.startsWith('webkit') ? acc[capitalize(prop)] = value : acc[prop] = value;
     return acc;
@@ -289,7 +208,7 @@ function convert(createElement, element) {
         if (key.indexOf('aria-') === 0 || key.indexOf('data-') === 0) {
           acc.attrs[key.toLowerCase()] = val;
         } else {
-          acc.attrs[humps.camelize(key)] = val;
+          acc.attrs[camelize(key)] = val;
         }
 
     }
@@ -321,45 +240,27 @@ function log () {
   }
 }
 
-function objectWithKey(key, value) {
-  return Array.isArray(value) && value.length > 0 || !Array.isArray(value) && value ? _defineProperty({}, key, value) : {};
-}
-
-function classList(props) {
-  var _classes;
-
-  var classes = (_classes = {
-    'fa-spin': props.spin,
-    'fa-pulse': props.pulse,
-    'fa-fw': props.fixedWidth,
-    'fa-inverse': props.inverse,
-    'fa-border': props.border,
-    'fa-li': props.listItem,
-    'fa-flip-horizontal': props.flip === 'horizontal' || props.flip === 'both',
-    'fa-flip-vertical': props.flip === 'vertical' || props.flip === 'both'
-  }, _defineProperty(_classes, "fa-".concat(props.size), props.size !== null), _defineProperty(_classes, "fa-rotate-".concat(props.rotation), props.rotation !== null), _defineProperty(_classes, "fa-pull-".concat(props.pull), props.pull !== null), _classes);
-  return Object.keys(classes).map(function (key) {
-    return classes[key] ? key : null;
-  }).filter(function (key) {
-    return key;
-  });
-}
-
+// Normalize icon arguments
 function normalizeIconArgs(icon$$1) {
+  // if the icon is null, there's nothing to do
   if (icon$$1 === null) {
     return null;
-  }
+  } // if the icon is an object and has a prefix and an icon name, return it
+
 
   if (_typeof(icon$$1) === 'object' && icon$$1.prefix && icon$$1.iconName) {
     return icon$$1;
-  }
+  } // if it's an array with length of two
+
 
   if (Array.isArray(icon$$1) && icon$$1.length === 2) {
+    // use the first item as prefix, second as icon name
     return {
       prefix: icon$$1[0],
       iconName: icon$$1[1]
     };
-  }
+  } // if it's a string, use it as the icon name
+
 
   if (typeof icon$$1 === 'string') {
     return {
@@ -367,6 +268,17 @@ function normalizeIconArgs(icon$$1) {
       iconName: icon$$1
     };
   }
+}
+
+// creates an object with a key of key
+// and a value of value
+// if certain conditions are met
+function objectWithKey(key, value) {
+  // if the value is a non-empty array
+  // or it's not an array but it is truthy
+  // then create the object with the key and the value
+  // if not, return an empty array
+  return Array.isArray(value) && value.length > 0 || !Array.isArray(value) && value ? _defineProperty({}, key, value) : {};
 }
 
 function FontAwesomeIcon(props) {

--- a/index.js
+++ b/index.js
@@ -111,143 +111,62 @@
     throw new TypeError("Invalid attempt to spread non-iterable instance");
   }
 
-  var commonjsGlobal = typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {};
+  // Get CSS class list from a props object
+  function classList(props) {
+    var _classes;
 
-  function createCommonjsModule(fn, module) {
-  	return module = { exports: {} }, fn(module, module.exports), module.exports;
+    var spin = props.spin,
+        pulse = props.pulse,
+        fixedWidth = props.fixedWidth,
+        inverse = props.inverse,
+        border = props.border,
+        listItem = props.listItem,
+        flip = props.flip,
+        size = props.size,
+        rotation = props.rotation,
+        pull = props.pull; // map of CSS class names to properties
+
+    var classes = (_classes = {
+      'fa-spin': spin,
+      'fa-pulse': pulse,
+      'fa-fw': fixedWidth,
+      'fa-inverse': inverse,
+      'fa-border': border,
+      'fa-li': listItem,
+      'fa-flip-horizontal': flip === 'horizontal' || flip === 'both',
+      'fa-flip-vertical': flip === 'vertical' || flip === 'both'
+    }, _defineProperty(_classes, "fa-".concat(size), typeof size !== 'undefined'), _defineProperty(_classes, "fa-rotate-".concat(rotation), typeof rotation !== 'undefined'), _defineProperty(_classes, "fa-pull-".concat(pull), typeof pull !== 'undefined'), _classes); // map over all the keys in the classes object
+    // return an array of the keys where the value for the key is not null
+
+    return Object.keys(classes).map(function (key) {
+      return classes[key] ? key : null;
+    }).filter(function (key) {
+      return key;
+    });
   }
 
-  var humps = createCommonjsModule(function (module) {
-  (function(global) {
+  // Camelize taken from humps
+  // humps is copyright © 2012+ Dom Christie
+  // Released under the MIT license.
+  // Performant way to determine if object coerces to a number
+  function _isNumerical(obj) {
+    obj = obj - 0; // eslint-disable-next-line no-self-compare
 
-    var _processKeys = function(convert, obj, options) {
-      if(!_isObject(obj) || _isDate(obj) || _isRegExp(obj) || _isBoolean(obj) || _isFunction(obj)) {
-        return obj;
-      }
+    return obj === obj;
+  }
 
-      var output,
-          i = 0,
-          l = 0;
+  function camelize(string) {
+    if (_isNumerical(string)) {
+      return string;
+    } // eslint-disable-next-line no-useless-escape
 
-      if(_isArray(obj)) {
-        output = [];
-        for(l=obj.length; i<l; i++) {
-          output.push(_processKeys(convert, obj[i], options));
-        }
-      }
-      else {
-        output = {};
-        for(var key in obj) {
-          if(Object.prototype.hasOwnProperty.call(obj, key)) {
-            output[convert(key, options)] = _processKeys(convert, obj[key], options);
-          }
-        }
-      }
-      return output;
-    };
 
-    // String conversion methods
+    string = string.replace(/[\-_\s]+(.)?/g, function (match, chr) {
+      return chr ? chr.toUpperCase() : '';
+    }); // Ensure 1st char is always lowercase
 
-    var separateWords = function(string, options) {
-      options = options || {};
-      var separator = options.separator || '_';
-      var split = options.split || /(?=[A-Z])/;
-
-      return string.split(split).join(separator);
-    };
-
-    var camelize = function(string) {
-      if (_isNumerical(string)) {
-        return string;
-      }
-      string = string.replace(/[\-_\s]+(.)?/g, function(match, chr) {
-        return chr ? chr.toUpperCase() : '';
-      });
-      // Ensure 1st char is always lowercase
-      return string.substr(0, 1).toLowerCase() + string.substr(1);
-    };
-
-    var pascalize = function(string) {
-      var camelized = camelize(string);
-      // Ensure 1st char is always uppercase
-      return camelized.substr(0, 1).toUpperCase() + camelized.substr(1);
-    };
-
-    var decamelize = function(string, options) {
-      return separateWords(string, options).toLowerCase();
-    };
-
-    // Utilities
-    // Taken from Underscore.js
-
-    var toString = Object.prototype.toString;
-
-    var _isFunction = function(obj) {
-      return typeof(obj) === 'function';
-    };
-    var _isObject = function(obj) {
-      return obj === Object(obj);
-    };
-    var _isArray = function(obj) {
-      return toString.call(obj) == '[object Array]';
-    };
-    var _isDate = function(obj) {
-      return toString.call(obj) == '[object Date]';
-    };
-    var _isRegExp = function(obj) {
-      return toString.call(obj) == '[object RegExp]';
-    };
-    var _isBoolean = function(obj) {
-      return toString.call(obj) == '[object Boolean]';
-    };
-
-    // Performant way to determine if obj coerces to a number
-    var _isNumerical = function(obj) {
-      obj = obj - 0;
-      return obj === obj;
-    };
-
-    // Sets up function which handles processing keys
-    // allowing the convert function to be modified by a callback
-    var _processor = function(convert, options) {
-      var callback = options && 'process' in options ? options.process : options;
-
-      if(typeof(callback) !== 'function') {
-        return convert;
-      }
-
-      return function(string, options) {
-        return callback(string, convert, options);
-      }
-    };
-
-    var humps = {
-      camelize: camelize,
-      decamelize: decamelize,
-      pascalize: pascalize,
-      depascalize: decamelize,
-      camelizeKeys: function(object, options) {
-        return _processKeys(_processor(camelize, options), object);
-      },
-      decamelizeKeys: function(object, options) {
-        return _processKeys(_processor(decamelize, options), object, options);
-      },
-      pascalizeKeys: function(object, options) {
-        return _processKeys(_processor(pascalize, options), object);
-      },
-      depascalizeKeys: function () {
-        return this.decamelizeKeys.apply(this, arguments);
-      }
-    };
-
-    if (module.exports) {
-      module.exports = humps;
-    } else {
-      global.humps = humps;
-    }
-
-  })(commonjsGlobal);
-  });
+    return string.substr(0, 1).toLowerCase() + string.substr(1);
+  }
 
   function capitalize(val) {
     return val.charAt(0).toUpperCase() + val.slice(1);
@@ -260,7 +179,7 @@
       return s;
     }).reduce(function (acc, pair) {
       var i = pair.indexOf(':');
-      var prop = humps.camelize(pair.slice(0, i));
+      var prop = camelize(pair.slice(0, i));
       var value = pair.slice(i + 1).trim();
       prop.startsWith('webkit') ? acc[capitalize(prop)] = value : acc[prop] = value;
       return acc;
@@ -294,7 +213,7 @@
           if (key.indexOf('aria-') === 0 || key.indexOf('data-') === 0) {
             acc.attrs[key.toLowerCase()] = val;
           } else {
-            acc.attrs[humps.camelize(key)] = val;
+            acc.attrs[camelize(key)] = val;
           }
 
       }
@@ -326,45 +245,27 @@
     }
   }
 
-  function objectWithKey(key, value) {
-    return Array.isArray(value) && value.length > 0 || !Array.isArray(value) && value ? _defineProperty({}, key, value) : {};
-  }
-
-  function classList(props) {
-    var _classes;
-
-    var classes = (_classes = {
-      'fa-spin': props.spin,
-      'fa-pulse': props.pulse,
-      'fa-fw': props.fixedWidth,
-      'fa-inverse': props.inverse,
-      'fa-border': props.border,
-      'fa-li': props.listItem,
-      'fa-flip-horizontal': props.flip === 'horizontal' || props.flip === 'both',
-      'fa-flip-vertical': props.flip === 'vertical' || props.flip === 'both'
-    }, _defineProperty(_classes, "fa-".concat(props.size), props.size !== null), _defineProperty(_classes, "fa-rotate-".concat(props.rotation), props.rotation !== null), _defineProperty(_classes, "fa-pull-".concat(props.pull), props.pull !== null), _classes);
-    return Object.keys(classes).map(function (key) {
-      return classes[key] ? key : null;
-    }).filter(function (key) {
-      return key;
-    });
-  }
-
+  // Normalize icon arguments
   function normalizeIconArgs(icon) {
+    // if the icon is null, there's nothing to do
     if (icon === null) {
       return null;
-    }
+    } // if the icon is an object and has a prefix and an icon name, return it
+
 
     if (_typeof(icon) === 'object' && icon.prefix && icon.iconName) {
       return icon;
-    }
+    } // if it's an array with length of two
+
 
     if (Array.isArray(icon) && icon.length === 2) {
+      // use the first item as prefix, second as icon name
       return {
         prefix: icon[0],
         iconName: icon[1]
       };
-    }
+    } // if it's a string, use it as the icon name
+
 
     if (typeof icon === 'string') {
       return {
@@ -372,6 +273,17 @@
         iconName: icon
       };
     }
+  }
+
+  // creates an object with a key of key
+  // and a value of value
+  // if certain conditions are met
+  function objectWithKey(key, value) {
+    // if the value is a non-empty array
+    // or it's not an array but it is truthy
+    // then create the object with the key and the value
+    // if not, return an empty array
+    return Array.isArray(value) && value.length > 0 || !Array.isArray(value) && value ? _defineProperty({}, key, value) : {};
   }
 
   function FontAwesomeIcon(props) {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "Prateek Goel <github.com/prateekgoel>",
     "Naor Torgeman <github.com/naortor>",
     "Matthew Hand <github.com/mmhand123>",
-    "calvinf <github.com/calvinf>"
+    "Calvin Freitas <github.com/calvinf>"
   ],
   "license": "MIT",
   "scripts": {
@@ -78,7 +78,6 @@
     "rollup-plugin-node-resolve": "^4.0.0"
   },
   "dependencies": {
-    "humps": "^2.0.1",
     "prop-types": "^15.5.10"
   },
   "files": [

--- a/src/components/FontAwesomeIcon.js
+++ b/src/components/FontAwesomeIcon.js
@@ -1,53 +1,11 @@
+import classList from '../utils/get-class-list-from-props'
 import convert from '../converter'
 import { icon, parse } from '@fortawesome/fontawesome-svg-core'
 import log from '../logger'
+import normalizeIconArgs from '../utils/normalize-icon-args'
+import objectWithKey from '../utils/object-with-key'
 import PropTypes from 'prop-types'
 import React from 'react'
-
-function objectWithKey(key, value) {
-  return (Array.isArray(value) && value.length > 0) ||
-    (!Array.isArray(value) && value)
-    ? { [key]: value }
-    : {}
-}
-
-function classList(props) {
-  let classes = {
-    'fa-spin': props.spin,
-    'fa-pulse': props.pulse,
-    'fa-fw': props.fixedWidth,
-    'fa-inverse': props.inverse,
-    'fa-border': props.border,
-    'fa-li': props.listItem,
-    'fa-flip-horizontal': props.flip === 'horizontal' || props.flip === 'both',
-    'fa-flip-vertical': props.flip === 'vertical' || props.flip === 'both',
-    [`fa-${props.size}`]: props.size !== null,
-    [`fa-rotate-${props.rotation}`]: props.rotation !== null,
-    [`fa-pull-${props.pull}`]: props.pull !== null
-  }
-
-  return Object.keys(classes)
-    .map(key => (classes[key] ? key : null))
-    .filter(key => key)
-}
-
-function normalizeIconArgs(icon) {
-  if (icon === null) {
-    return null
-  }
-
-  if (typeof icon === 'object' && icon.prefix && icon.iconName) {
-    return icon
-  }
-
-  if (Array.isArray(icon) && icon.length === 2) {
-    return { prefix: icon[0], iconName: icon[1] }
-  }
-
-  if (typeof icon === 'string') {
-    return { prefix: 'fas', iconName: icon }
-  }
-}
 
 export default function FontAwesomeIcon(props) {
   const { icon: iconArgs, mask: maskArgs, symbol, className, title } = props

--- a/src/converter.js
+++ b/src/converter.js
@@ -1,4 +1,4 @@
-import humps from 'humps'
+import camelize from './utils/camelize'
 
 function capitalize(val) {
   return val.charAt(0).toUpperCase() + val.slice(1)
@@ -11,7 +11,7 @@ function styleToObject(style) {
     .filter(s => s)
     .reduce((acc, pair) => {
       const i = pair.indexOf(':')
-      const prop = humps.camelize(pair.slice(0, i))
+      const prop = camelize(pair.slice(0, i))
       const value = pair.slice(i + 1).trim()
 
       prop.startsWith('webkit')
@@ -47,7 +47,7 @@ function convert(createElement, element, extraProps = {}) {
           if (key.indexOf('aria-') === 0 || key.indexOf('data-') === 0) {
             acc.attrs[key.toLowerCase()] = val
           } else {
-            acc.attrs[humps.camelize(key)] = val
+            acc.attrs[camelize(key)] = val
           }
       }
 

--- a/src/utils/__tests__/camelize.test.js
+++ b/src/utils/__tests__/camelize.test.js
@@ -1,0 +1,19 @@
+import camelize from '../camelize'
+
+describe('camelize', () => {
+  test('numerical values return same value', () => {
+    const numerical = 999
+    expect(camelize(numerical)).toBe(numerical)
+  })
+
+  test('first char is always lowercase', () => {
+    expect(camelize('f-a')).toBe('fA')
+    expect(camelize('F-a')).toBe('fA')
+  })
+
+  test('multiple humps', () => {
+    expect(camelize('fa-coffee')).toBe('faCoffee')
+    expect(camelize('fa-fake-icon')).toBe('faFakeIcon')
+    expect(camelize('fa-fake-icon-longer')).toBe('faFakeIconLonger')
+  })
+})

--- a/src/utils/__tests__/get-class-list-from-props.test.js
+++ b/src/utils/__tests__/get-class-list-from-props.test.js
@@ -1,0 +1,81 @@
+import getClassList from '../get-class-list-from-props'
+
+describe('get class list', () => {
+  test('test the booleans', () => {
+    // the six we're testing plus the three defaults
+    const NUM_CLASSES = 6
+
+    const props = {
+      spin: true,
+      pulse: true,
+      fixedWidth: true,
+      inverse: true,
+      border: true,
+      listItem: true
+    }
+
+    const classList = getClassList(props)
+    expect(classList.length).toBe(NUM_CLASSES)
+    expect(classList).toStrictEqual([
+      'fa-spin',
+      'fa-pulse',
+      'fa-fw',
+      'fa-inverse',
+      'fa-border',
+      'fa-li'
+    ])
+  })
+
+  test('flip', () => {
+    const HORIZONTAL = 'fa-flip-horizontal'
+    const VERTICAL = 'fa-flip-vertical'
+
+    const horizontalList = getClassList({
+      flip: 'horizontal'
+    })
+
+    const verticalList = getClassList({
+      flip: 'vertical'
+    })
+
+    const bothList = getClassList({
+      flip: 'both'
+    })
+
+    expect(horizontalList).toContain(HORIZONTAL)
+    expect(verticalList).toContain(VERTICAL)
+
+    expect(bothList.length).toBe(2)
+    expect(bothList).toContain(HORIZONTAL)
+    expect(bothList).toContain(VERTICAL)
+  })
+
+  test('size', () => {
+    function testSize(size) {
+      expect(getClassList({ size })).toStrictEqual([`fa-${size}`])
+    }
+
+    testSize('xs')
+  })
+
+  test('rotation', () => {
+    function testRotation(rotation) {
+      expect(getClassList({ rotation })).toStrictEqual([
+        `fa-rotate-${rotation}`
+      ])
+    }
+
+    testRotation(90)
+    testRotation(180)
+    testRotation(270)
+  })
+
+  test('pull', () => {
+    function testPull(pull) {
+      expect(getClassList({ pull })).toStrictEqual([`fa-pull-${pull}`])
+    }
+
+    testPull('left')
+    testPull('right')
+  })
+})

--- a/src/utils/__tests__/normalize-icon-args.test.js
+++ b/src/utils/__tests__/normalize-icon-args.test.js
@@ -1,0 +1,34 @@
+import normalizeIconArgs from '../normalize-icon-args'
+
+describe('normalize icon args', () => {
+  const PREFIX = 'far'
+  const NAME = 'circle'
+
+  test('handle null', () => {
+    expect(normalizeIconArgs(null)).toBeNull()
+  })
+
+  test('handle object', () => {
+    const icon = {
+      prefix: 'far',
+      iconName: 'circle'
+    }
+    expect(normalizeIconArgs(icon)).toStrictEqual(icon)
+  })
+
+  test('handle array', () => {
+    const icon = [PREFIX, NAME]
+    expect(normalizeIconArgs(icon)).toStrictEqual({
+      prefix: PREFIX,
+      iconName: NAME
+    })
+  })
+
+  test('handle string', () => {
+    const DEFAULT_PREFIX = 'fas'
+    expect(normalizeIconArgs(NAME)).toStrictEqual({
+      prefix: DEFAULT_PREFIX,
+      iconName: NAME
+    })
+  })
+})

--- a/src/utils/__tests__/object-with-key.test.js
+++ b/src/utils/__tests__/object-with-key.test.js
@@ -1,0 +1,28 @@
+import objectWithKey from '../object-with-key'
+
+describe('object with key', () => {
+  const KEY = 'my-key'
+
+  test('value is array length greater than 1', () => {
+    const VALUE = [1]
+    expect(objectWithKey(KEY, [1])).toStrictEqual({
+      [KEY]: VALUE
+    })
+  })
+
+  test('value array empty', () => {
+    expect(objectWithKey(KEY, [])).toStrictEqual({})
+  })
+
+  test('value is not array', () => {
+    const VALUE = 'value'
+    expect(objectWithKey(KEY, VALUE)).toStrictEqual({
+      [KEY]: VALUE
+    })
+  })
+
+  test('value not truthy', () => {
+    expect(objectWithKey(KEY)).toStrictEqual({})
+    expect(objectWithKey(KEY, null)).toStrictEqual({})
+  })
+})

--- a/src/utils/camelize.js
+++ b/src/utils/camelize.js
@@ -1,0 +1,25 @@
+// Camelize taken from humps
+// humps is copyright © 2012+ Dom Christie
+// Released under the MIT license.
+
+// Performant way to determine if object coerces to a number
+function _isNumerical(obj) {
+  obj = obj - 0
+
+  // eslint-disable-next-line no-self-compare
+  return obj === obj
+}
+
+export default function camelize(string) {
+  if (_isNumerical(string)) {
+    return string
+  }
+
+  // eslint-disable-next-line no-useless-escape
+  string = string.replace(/[\-_\s]+(.)?/g, function(match, chr) {
+    return chr ? chr.toUpperCase() : ''
+  })
+
+  // Ensure 1st char is always lowercase
+  return string.substr(0, 1).toLowerCase() + string.substr(1)
+}

--- a/src/utils/get-class-list-from-props.js
+++ b/src/utils/get-class-list-from-props.js
@@ -1,0 +1,36 @@
+// Get CSS class list from a props object
+export default function classList(props) {
+  const {
+    spin,
+    pulse,
+    fixedWidth,
+    inverse,
+    border,
+    listItem,
+    flip,
+    size,
+    rotation,
+    pull
+  } = props
+
+  // map of CSS class names to properties
+  let classes = {
+    'fa-spin': spin,
+    'fa-pulse': pulse,
+    'fa-fw': fixedWidth,
+    'fa-inverse': inverse,
+    'fa-border': border,
+    'fa-li': listItem,
+    'fa-flip-horizontal': flip === 'horizontal' || flip === 'both',
+    'fa-flip-vertical': flip === 'vertical' || flip === 'both',
+    [`fa-${size}`]: typeof size !== 'undefined',
+    [`fa-rotate-${rotation}`]: typeof rotation !== 'undefined',
+    [`fa-pull-${pull}`]: typeof pull !== 'undefined'
+  }
+
+  // map over all the keys in the classes object
+  // return an array of the keys where the value for the key is not null
+  return Object.keys(classes)
+    .map(key => (classes[key] ? key : null))
+    .filter(key => key)
+}

--- a/src/utils/normalize-icon-args.js
+++ b/src/utils/normalize-icon-args.js
@@ -1,0 +1,23 @@
+// Normalize icon arguments
+export default function normalizeIconArgs(icon) {
+  // if the icon is null, there's nothing to do
+  if (icon === null) {
+    return null
+  }
+
+  // if the icon is an object and has a prefix and an icon name, return it
+  if (typeof icon === 'object' && icon.prefix && icon.iconName) {
+    return icon
+  }
+
+  // if it's an array with length of two
+  if (Array.isArray(icon) && icon.length === 2) {
+    // use the first item as prefix, second as icon name
+    return { prefix: icon[0], iconName: icon[1] }
+  }
+
+  // if it's a string, use it as the icon name
+  if (typeof icon === 'string') {
+    return { prefix: 'fas', iconName: icon }
+  }
+}

--- a/src/utils/object-with-key.js
+++ b/src/utils/object-with-key.js
@@ -1,0 +1,13 @@
+// creates an object with a key of key
+// and a value of value
+// if certain conditions are met
+export default function objectWithKey(key, value) {
+  // if the value is a non-empty array
+  // or it's not an array but it is truthy
+  // then create the object with the key and the value
+  // if not, return an empty array
+  return (Array.isArray(value) && value.length > 0) ||
+    (!Array.isArray(value) && value)
+    ? { [key]: value }
+    : {}
+}


### PR DESCRIPTION
Use local camelize function forked from humps to reduce bundle size and eliminate a dependency.

Migrate getClassListWithProps, normalizeIconArgs, objectWithKey to separate utils modules.

Includes tests.