### PR TITLE
Suggested doc edit to explain CSS sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ loaded an icon bundle. See the sections above for the details.
 <FontAwesomeIcon icon="spinner" size="lg" />
 <FontAwesomeIcon icon="spinner" size="6x" />
 ```
+Note that icon size can be controlled with the CSS `font-size` attribute, and `FontAwesomeIcon`'s `size` prop determines icon size relative to the current `font-size`.
 
 [Fixed width](https://fontawesome.com/how-to-use/on-the-web/styling/fixed-width-icons):
 


### PR DESCRIPTION
I was trying to make my icon size responsive, and it took me quite a bit of work to figure/find out that I could use the CSS font-size attribute. This may be obvious to folks upgrading from FA4 (though maybe not), but it is not well documented. Thanks for your work on this project!

(Also, SO does not seem to have a react-fontawesome tag, it has "react-font-awesome". Believe it or not, this created some confusion or at least hesitation for me.)