### PR TITLE
use React.forwardRef to allow for ref passing to access icon dom node

### DIFF
--- a/src/components/FontAwesomeIcon.js
+++ b/src/components/FontAwesomeIcon.js
@@ -49,7 +49,7 @@ function normalizeIconArgs(icon) {
   }
 }
 
-export default function FontAwesomeIcon(props) {
+const FontAwesomeIcon = React.forwardRef(function(props, forwardedRef) {
   const { icon: iconArgs, mask: maskArgs, symbol, className, title } = props
 
   const iconLookup = normalizeIconArgs(iconArgs)
@@ -79,7 +79,7 @@ export default function FontAwesomeIcon(props) {
   }
 
   const { abstract } = renderedIcon
-  const extraProps = {}
+  const extraProps = { ref: forwardedRef }
 
   Object.keys(props).forEach(key => {
     if (!FontAwesomeIcon.defaultProps.hasOwnProperty(key)) {
@@ -88,7 +88,9 @@ export default function FontAwesomeIcon(props) {
   })
 
   return convertCurry(abstract[0], extraProps)
-}
+})
+
+export default FontAwesomeIcon
 
 FontAwesomeIcon.displayName = 'FontAwesomeIcon'
 

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -274,3 +274,17 @@ describe('title', () => {
     expect(vm.children[0].children[0]).toBe('Coffee')
   })
 })
+
+describe('ref', () => {
+  test('ref prop will point to svg element', () => {
+    const ref = React.createRef()
+    let type = null
+    const options = {
+      createNodeMock: element => {
+        type = element.type
+      }
+    }
+    renderer.create(<FontAwesomeIcon icon={faCoffee} ref={ref} />, options)
+    expect(type).toBe('svg')
+  })
+})


### PR DESCRIPTION
Not sure if this will break any other code, but nice to be able to pass a `ref` prop to the component to get access to the rendered element