### PR TITLE
Deprecate Props in favor of FontAwesomeIconProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,9 +10,14 @@ import {
   FaSymbol
 } from '@fortawesome/fontawesome-svg-core'
 
-export function FontAwesomeIcon(props: Props): JSX.Element
+export function FontAwesomeIcon(props: FontAwesomeIconProps): JSX.Element
 
-export interface Props {
+/**
+ * @deprecated use FontAwesomeIconProps
+ */
+export type Props = FontAwesomeIconProps
+
+export interface FontAwesomeIconProps {
   icon: IconProp
   mask?: IconProp
   className?: string


### PR DESCRIPTION
Closes #257 

Favoured deprecation over renaming so as not to break the public api