### PR TITLE
Extend to allow string rather arrays

### DIFF
--- a/src/utils/__tests__/normalize-icon-args.test.js
+++ b/src/utils/__tests__/normalize-icon-args.test.js
@@ -2,7 +2,9 @@ import normalizeIconArgs from '../normalize-icon-args'
 
 describe('normalize icon args', () => {
   const PREFIX = 'far'
+  const FALPREFIX = 'fal'
   const NAME = 'circle'
+  const FULLNAME = 'fal-circle'
 
   test('handle null', () => {
     expect(normalizeIconArgs(null)).toBeNull()
@@ -29,6 +31,15 @@ describe('normalize icon args', () => {
     expect(normalizeIconArgs(NAME)).toStrictEqual({
       prefix: DEFAULT_PREFIX,
       iconName: NAME
+    })
+  })
+  
+  
+  test('handle prefixed string', () => {
+    const DEFAULT_PREFIX = 'fas'
+    expect(normalizeIconArgs(FULLNAME)).toStrictEqual({
+      prefix: FALPREFIX,
+      iconName: FULLNAME
     })
   })
 })

--- a/src/utils/normalize-icon-args.js
+++ b/src/utils/normalize-icon-args.js
@@ -18,6 +18,15 @@ export default function normalizeIconArgs(icon) {
 
   // if it's a string, use it as the icon name
   if (typeof icon === 'string') {
+    if (icon.startsWith('far-')) {
+      return { prefix: 'far', iconName: icon.replace('far-','') }
+    }
+    if (icon.startsWith('fas-')) {
+      return { prefix: 'fas', iconName: icon.replace('fas-','') }
+    }
+    if (icon.startsWith('fal-')) {
+      return { prefix: 'fal', iconName: icon.replace('fal-','') }
+    }
     return { prefix: 'fas', iconName: icon }
   }
 }


### PR DESCRIPTION
This will help rather than switching from string to array, you can just quickly and efficiently change the string to use a different variation of the icon.

e.g: `fal-coffee` instead of `['fal', 'coffee']`