### PR TITLE
Add DOM attributes to FontAwesomeIconProps to Typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="react" />
-import { CSSProperties } from 'react'
+import { CSSProperties, DOMAttributes } from 'react'
 import {
   Transform,
   IconProp,
@@ -17,7 +17,10 @@ export function FontAwesomeIcon(props: FontAwesomeIconProps): JSX.Element
  */
 export type Props = FontAwesomeIconProps
 
-export interface FontAwesomeIconProps {
+// This is identical to the version of Omit in Typescript 3.5. It is included for compatibility with older versions of Typescript.
+type BackwardCompatibleOmit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
+
+export interface FontAwesomeIconProps extends BackwardCompatibleOmit<DOMAttributes<SVGSVGElement>, 'children' | 'mask'> {
   icon: IconProp
   mask?: IconProp
   className?: string


### PR DESCRIPTION
This allows the use of event handlers such as onClick, etc. If we want to limit ourselves to fairly recent versions of TS (or code our own which is fairly simple), we can use the omit type to omit the few types we don't need.

I didn't use SVGElement props as I'm not sure if that's a level of access we want to give but I can if desired.