### PR TITLE
add null check when building up class list (fixes #289)

### DIFF
--- a/src/utils/__tests__/get-class-list-from-props.test.js
+++ b/src/utils/__tests__/get-class-list-from-props.test.js
@@ -78,4 +78,43 @@ describe('get class list', () => {
     testPull('left')
     testPull('right')
   })
+
+  describe('when some props are null', () => {
+    function testNulls(prop) {
+      const NUM_CLASSES = 6
+
+      const props = {
+        spin: true,
+        pulse: true,
+        fixedWidth: true,
+        inverse: true,
+        border: true,
+        listItem: true,
+        [prop]: null
+      }
+
+      const classList = getClassList(props)
+      expect(classList.length).toBe(NUM_CLASSES)
+      expect(classList).toStrictEqual([
+        'fa-spin',
+        'fa-pulse',
+        'fa-fw',
+        'fa-inverse',
+        'fa-border',
+        'fa-li'
+      ])
+    }
+
+    test('pull', () => {
+      testNulls('pull')
+    })
+
+    test('rotation', () => {
+      testNulls('rotation')
+    })
+
+    test('size', () => {
+      testNulls('size')
+    })
+  })
 })

--- a/src/utils/get-class-list-from-props.js
+++ b/src/utils/get-class-list-from-props.js
@@ -23,9 +23,10 @@ export default function classList(props) {
     'fa-li': listItem,
     'fa-flip-horizontal': flip === 'horizontal' || flip === 'both',
     'fa-flip-vertical': flip === 'vertical' || flip === 'both',
-    [`fa-${size}`]: typeof size !== 'undefined',
-    [`fa-rotate-${rotation}`]: typeof rotation !== 'undefined',
-    [`fa-pull-${pull}`]: typeof pull !== 'undefined',
+    [`fa-${size}`]: typeof size !== 'undefined' && size !== null,
+    [`fa-rotate-${rotation}`]:
+      typeof rotation !== 'undefined' && rotation !== null,
+    [`fa-pull-${pull}`]: typeof pull !== 'undefined' && pull !== null,
     'fa-swap-opacity': props.swapOpacity
   }
 


### PR DESCRIPTION
I ran into this issue today when I noticed some failing snapshot tests. I saw that the issue had been reported already but looked pretty straightforward to fix.