### PR TITLE
Fix next-css inhalation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,7 +547,7 @@ Next.js app.
 Install `@zeit/next-css`:
 
 ```
-npm install --save-dev @zeit-css
+npm install --save-dev @zeit/next-css
 ```
 
 You may want to use `--save` instead of `--save-dev` depending on how your `package.json` is organized.


### PR DESCRIPTION
The installation command in the NextJS section is currently incorrect.