### PR TITLE
fix: normalize icon args util func

### DIFF
--- a/src/utils/__tests__/is-object.test.js
+++ b/src/utils/__tests__/is-object.test.js
@@ -1,0 +1,13 @@
+import isObject from '../is-object'
+
+describe('object', () => {
+  test('actual object', () => {
+    const obj = {a: 1}
+    expect(isObject(obj)).toBe(true)
+  })
+
+  test('not an array', () => {
+    const arr = [1]
+    expect(isObject(arr)).toBe(false)
+  })
+})

--- a/src/utils/is-object.js
+++ b/src/utils/is-object.js
@@ -1,0 +1,3 @@
+export default function isObject(val) {
+ return Object.prototype.toString.call(val) === "[object Object]";
+}

--- a/src/utils/normalize-icon-args.js
+++ b/src/utils/normalize-icon-args.js
@@ -1,3 +1,5 @@
+import isObject from './is-object';
+
 // Normalize icon arguments
 export default function normalizeIconArgs(icon) {
   // if the icon is null, there's nothing to do
@@ -5,15 +7,15 @@ export default function normalizeIconArgs(icon) {
     return null
   }
   
+  // if the icon is an object and has a prefix and an icon name, return it
+  if (isObject(icon) && icon.prefix && icon.iconName) {
+    return icon
+  }
+  
   // if it's an array with length of two
   if (Array.isArray(icon) && icon.length === 2) {
     // use the first item as prefix, second as icon name
     return { prefix: icon[0], iconName: icon[1] }
-  }
-
-  // if the icon is an object and has a prefix and an icon name, return it
-  if (typeof icon === 'object' && icon.prefix && icon.iconName) {
-    return icon
   }
 
   // if it's a string, use it as the icon name

--- a/src/utils/normalize-icon-args.js
+++ b/src/utils/normalize-icon-args.js
@@ -4,16 +4,16 @@ export default function normalizeIconArgs(icon) {
   if (icon === null) {
     return null
   }
-
-  // if the icon is an object and has a prefix and an icon name, return it
-  if (typeof icon === 'object' && icon.prefix && icon.iconName) {
-    return icon
-  }
-
+  
   // if it's an array with length of two
   if (Array.isArray(icon) && icon.length === 2) {
     // use the first item as prefix, second as icon name
     return { prefix: icon[0], iconName: icon[1] }
+  }
+
+  // if the icon is an object and has a prefix and an icon name, return it
+  if (typeof icon === 'object' && icon.prefix && icon.iconName) {
+    return icon
   }
 
   // if it's a string, use it as the icon name


### PR DESCRIPTION
Only `typeof` operator was being used to check `icon` type. It might be an array but still, the condition would pass. In this PR, I created another utility function to check whether the value is an actual object or not.

For example: 
const icon = ['fas', 'arrow-left'];
icon. prefix = 'a';
icon. iconName = 'b';

If you provided this `icon` variable into the previous condition it would pass and return undesirable result. Because it would fullfil the condition.
`if (typeof icon === 'object' && icon.prefix && icon.iconName) {`


Now if you pass the same variable, the condition will mismatch and it'll be passed to the next condition.
`if (isObject(icon) && icon.prefix && icon.iconName) {`
