### PR TITLE
Feature/memorization

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "prettier": "^1.11.1",
     "pretty-quick": "^1.2.2",
     "prop-types": "^15.5.10",
-    "react": "^16.8.0",
+    "react": "^16.6.0",
     "react-test-renderer": "^16.2.0",
     "rollup": "^0.57.1",
     "rollup-plugin-babel": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "clean": "rm -f index.js && rm -f index.es.js"
   },
   "lint-staged": {
-    "README.md": ["markdown-toc -i"]
+    "README.md": [
+      "markdown-toc -i"
+    ]
   },
   "peerDependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.0-7",
@@ -60,7 +62,7 @@
     "prettier": "^1.11.1",
     "pretty-quick": "^1.2.2",
     "prop-types": "^15.5.10",
-    "react": "^16.2.0",
+    "react": "^16.8.0",
     "react-test-renderer": "^16.2.0",
     "rollup": "^0.57.1",
     "rollup-plugin-babel": "^3.0.2",
@@ -71,5 +73,9 @@
     "humps": "^2.0.1",
     "prop-types": "^15.5.10"
   },
-  "files": ["index.js", "index.es.js", "index.d.ts"]
+  "files": [
+    "index.js",
+    "index.es.js",
+    "index.d.ts"
+  ]
 }

--- a/src/components/FontAwesomeIcon.js
+++ b/src/components/FontAwesomeIcon.js
@@ -2,7 +2,7 @@ import convert from '../converter'
 import { icon, parse } from '@fortawesome/fontawesome-svg-core'
 import log from '../logger'
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { memo } from 'react'
 
 function objectWithKey(key, value) {
   return (Array.isArray(value) && value.length > 0) ||
@@ -49,7 +49,7 @@ function normalizeIconArgs(icon) {
   }
 }
 
-export default function FontAwesomeIcon(props) {
+function FontAwesomeIcon(props) {
   const { icon: iconArgs, mask: maskArgs, symbol, className } = props
 
   const iconLookup = normalizeIconArgs(iconArgs)
@@ -164,3 +164,5 @@ FontAwesomeIcon.defaultProps = {
 }
 
 const convertCurry = convert.bind(null, React.createElement)
+
+export default memo(FontAwesomeIcon)


### PR DESCRIPTION
In my own projects I use icons this way this for preventing rerendering:

```js
import React, { memo } from 'react'
import { FontAwesomeIcon as Icon } from '@fortawesome/react-fontawesome'

let FontAwesomeIcon = props => <Icon {...props} />

FontAwesomeIcon = memo(FontAwesomeIcon)

export { FontAwesomeIcon }
```

What about upping react version and using `memo` by default?