### PR TITLE
Update forwardedRef type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,7 @@ export type Props = FontAwesomeIconProps
 type BackwardCompatibleOmit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
 
 export interface FontAwesomeIconProps extends BackwardCompatibleOmit<SVGAttributes<SVGSVGElement>, 'children' | 'mask' | 'transform'> {
-  forwardedRef?: ((e: any) => void) | React.RefObject<any>
+  forwardedRef?: ((e: any) => void) | React.MutableRefObject<any> | null
   icon: IconProp
   mask?: IconProp
   className?: string


### PR DESCRIPTION
The `forwardedRef` is mutable and it can also be `null`. Reference: https://react-typescript-cheatsheet.netlify.app/docs/basic/getting-started/forward_and_create_ref/.
Just updated the types accordingly.

Fixes #393 