### PR TITLE
Add titleId to proptypes and ts declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -41,5 +41,6 @@ export interface FontAwesomeIconProps extends BackwardCompatibleOmit<SVGAttribut
   style?: CSSProperties
   tabIndex?: number;
   title?: string;
+  titleId?: string;
   swapOpacity?: boolean;
 }

--- a/index.es.js
+++ b/index.es.js
@@ -357,6 +357,7 @@ FontAwesomeIcon.propTypes = {
   spin: PropTypes.bool,
   symbol: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
   title: PropTypes.string,
+  titleId: PropTypes.string,
   transform: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   swapOpacity: PropTypes.bool
 };
@@ -376,6 +377,7 @@ FontAwesomeIcon.defaultProps = {
   spin: false,
   symbol: false,
   title: '',
+  titleId: null,
   transform: null,
   swapOpacity: false
 };

--- a/index.js
+++ b/index.js
@@ -362,6 +362,7 @@
     spin: PropTypes.bool,
     symbol: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
     title: PropTypes.string,
+    titleId: PropTypes.string,
     transform: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     swapOpacity: PropTypes.bool
   };
@@ -381,6 +382,7 @@
     spin: false,
     symbol: false,
     title: '',
+    titleId: null,
     transform: null,
     swapOpacity: false
   };

--- a/src/components/FontAwesomeIcon.js
+++ b/src/components/FontAwesomeIcon.js
@@ -112,6 +112,8 @@ FontAwesomeIcon.propTypes = {
 
   title: PropTypes.string,
 
+  titleId: PropTypes.string,
+
   transform: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
 
   swapOpacity: PropTypes.bool
@@ -133,6 +135,7 @@ FontAwesomeIcon.defaultProps = {
   spin: false,
   symbol: false,
   title: '',
+  titleId: null,
   transform: null,
   swapOpacity: false
 }


### PR DESCRIPTION
Add `titleId` to proptypes and ts declaration file.

This is specially important since props not listed in `FontAwesomeIcon.defaultProps` will be serialized into the resulting HTML, making React throw a warning since `titleId` is not a valid attribute.