### PR TITLE
bug: Brian Talbot was displayed two times in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ The Font Awesome team:
 |   <img src="https://github.com/robmadole.png?size=72" />   | Rob Madole     | [@robmadole](https://github.com/robmadole)         |
 |  <img src="https://github.com/mlwilkerson.png?size=72" />  | Mike Wilkerson | [@mlwilkerson](https://github.com/mlwilkerson)     |
 |     <img src="https://github.com/talbs.png?size=72" />     | Brian Talbot   | [@talbs](https://github.com/talbs)                 |
-|     <img src="https://github.com/talbs.png?size=72" />     | Brian Talbot   | [@talbs](https://github.com/talbs)                 |
 | <img src="https://github.com/jasonlundien.png?size=72" />  | Jason Lundien  | [@jasonlundien](https://github.com/jasonlundien)   |
 
 ## Releasing this project (only project owners can do this)


### PR DESCRIPTION
Briant Talbot was being displayed two times in the readme contributors section.


<img width="1097" alt="Screenshot 2021-06-21 at 3 43 30 PM" src="https://user-images.githubusercontent.com/45518343/122746224-7046ed80-d2a7-11eb-8402-86332a3294d2.png">


Now he is displayed just once.