### PR TITLE
Add titleId to TypeScript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -41,5 +41,6 @@ export interface FontAwesomeIconProps extends BackwardCompatibleOmit<SVGAttribut
   style?: CSSProperties
   tabIndex?: number;
   title?: string;
+  titleId?: string;
   swapOpacity?: boolean;
 }


### PR DESCRIPTION
I'm trying to use FontAwesomeIcon with Server Side Rendering, and ran into the issue with the autogenerated ids on svg `<title>` elements failing to match between client and server.  It appears there's already a `titleId` prop that has been added to solve this, but it seems to be missing from the Typescript typings.  This PR adds it.  As far as I could see there were no automated tests for the typescript typings or any other additional things that I should update, but let me know if I missed something.