### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/index.es.js
+++ b/index.es.js
@@ -192,7 +192,7 @@ function camelize(string) {
     return chr ? chr.toUpperCase() : '';
   }); // Ensure 1st char is always lowercase
 
-  return string.substr(0, 1).toLowerCase() + string.substr(1);
+  return string.slice(0, 1).toLowerCase() + string.slice(1);
 }
 
 var _excluded$1 = ["style"];

--- a/index.js
+++ b/index.js
@@ -199,7 +199,7 @@
       return chr ? chr.toUpperCase() : '';
     }); // Ensure 1st char is always lowercase
 
-    return string.substr(0, 1).toLowerCase() + string.substr(1);
+    return string.slice(0, 1).toLowerCase() + string.slice(1);
   }
 
   var _excluded$1 = ["style"];

--- a/src/utils/camelize.js
+++ b/src/utils/camelize.js
@@ -21,5 +21,5 @@ export default function camelize(string) {
   })
 
   // Ensure 1st char is always lowercase
-  return string.substr(0, 1).toLowerCase() + string.substr(1)
+  return string.slice(0, 1).toLowerCase() + string.slice(1)
 }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.