### PR TITLE
Don't skip the majority of tests

### DIFF
--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -374,7 +374,7 @@ describe('title', () => {
     expect(vm.children[0].children[0]).toBe('Coffee')
   })
 
-  test.only('will use an explicit titleId', () => {
+  test('will use an explicit titleId', () => {
     const vm = mount({ icon: faCoffee, title: 'Coffee', titleId: 'coffee-title' })
 
     expect(vm.props['aria-labelledby']).toBe('svg-inline--fa-title-coffee-title')


### PR DESCRIPTION
When implementing `forwardRef`, I tried first changing the relevant test, and couldn't get it to fail no matter what I tried. Turns out it, along with most other tests, was being skipped because of this `test.only`! Luckily they all still seem to pass.