### PR TITLE
Add a default to className

### DIFF
--- a/index.es.js
+++ b/index.es.js
@@ -333,7 +333,8 @@ var FontAwesomeIcon = /*#__PURE__*/React.forwardRef(function (props, ref) {
   var iconArgs = props.icon,
       maskArgs = props.mask,
       symbol = props.symbol,
-      className = props.className,
+      _props$className = props.className,
+      className = _props$className === void 0 ? "" : _props$className,
       title = props.title,
       titleId = props.titleId,
       maskId = props.maskId;

--- a/index.js
+++ b/index.js
@@ -340,7 +340,8 @@
     var iconArgs = props.icon,
         maskArgs = props.mask,
         symbol = props.symbol,
-        className = props.className,
+        _props$className = props.className,
+        className = _props$className === void 0 ? "" : _props$className,
         title = props.title,
         titleId = props.titleId,
         maskId = props.maskId;

--- a/src/components/FontAwesomeIcon.js
+++ b/src/components/FontAwesomeIcon.js
@@ -12,7 +12,7 @@ const FontAwesomeIcon = React.forwardRef((props, ref) => {
     icon: iconArgs,
     mask: maskArgs,
     symbol,
-    className,
+    className = "",
     title,
     titleId,
     maskId


### PR DESCRIPTION
I was getting errors with `className.split` in my project.

Update: I realized this is cause I'm using the new React v19, which silently ignores `prop-types`.