### PR TITLE
Reduce bundle size by removing runtime props validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "@fortawesome/react-fontawesome",
       "version": "0.2.2",
       "license": "MIT",
-      "dependencies": {
-        "prop-types": "^15.8.1"
-      },
       "devDependencies": {
         "@babel/core": "^7.16.7",
         "@babel/plugin-external-helpers": "^7.16.7",
@@ -7801,7 +7798,8 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "3.13.1",
@@ -8276,6 +8274,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -8574,6 +8573,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9100,6 +9100,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -9109,7 +9110,8 @@
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
     },
     "node_modules/psl": {
       "version": "1.8.0",
@@ -16429,7 +16431,8 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -16791,6 +16794,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -17032,7 +17036,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-inspect": {
       "version": "1.12.0",
@@ -17406,6 +17411,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -17415,7 +17421,8 @@
         "react-is": {
           "version": "16.13.1",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -91,9 +91,6 @@
     "rollup": "^2.64.0",
     "semver": "^7.3.7"
   },
-  "dependencies": {
-    "prop-types": "^15.8.1"
-  },
   "files": [
     "index.js",
     "index.es.js",

--- a/src/components/FontAwesomeIcon.js
+++ b/src/components/FontAwesomeIcon.js
@@ -4,7 +4,6 @@ import { icon, parse } from '@fortawesome/fontawesome-svg-core'
 import log from '../logger'
 import normalizeIconArgs from '../utils/normalize-icon-args'
 import objectWithKey from '../utils/object-with-key'
-import PropTypes from 'prop-types'
 import React from 'react'
 
 const defaultProps = {
@@ -92,87 +91,6 @@ const FontAwesomeIcon = React.forwardRef((props, ref) => {
 })
 
 FontAwesomeIcon.displayName = 'FontAwesomeIcon'
-
-FontAwesomeIcon.propTypes = {
-  beat: PropTypes.bool,
-
-  border: PropTypes.bool,
-
-  beatFade: PropTypes.bool,
-
-  bounce: PropTypes.bool,
-
-  className: PropTypes.string,
-
-  fade: PropTypes.bool,
-
-  flash: PropTypes.bool,
-
-  mask: PropTypes.oneOfType([
-    PropTypes.object,
-    PropTypes.array,
-    PropTypes.string
-  ]),
-
-  maskId: PropTypes.string,
-
-  fixedWidth: PropTypes.bool,
-
-  inverse: PropTypes.bool,
-
-  flip: PropTypes.oneOf([true, false, 'horizontal', 'vertical', 'both']),
-
-  icon: PropTypes.oneOfType([
-    PropTypes.object,
-    PropTypes.array,
-    PropTypes.string
-  ]),
-
-  listItem: PropTypes.bool,
-
-  pull: PropTypes.oneOf(['right', 'left']),
-
-  pulse: PropTypes.bool,
-
-  rotation: PropTypes.oneOf([0, 90, 180, 270]),
-
-  shake: PropTypes.bool,
-
-  size: PropTypes.oneOf([
-    '2xs',
-    'xs',
-    'sm',
-    'lg',
-    'xl',
-    '2xl',
-    '1x',
-    '2x',
-    '3x',
-    '4x',
-    '5x',
-    '6x',
-    '7x',
-    '8x',
-    '9x',
-    '10x'
-  ]),
-
-  spin: PropTypes.bool,
-
-  spinPulse: PropTypes.bool,
-
-  spinReverse: PropTypes.bool,
-
-  symbol: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
-
-  title: PropTypes.string,
-
-  titleId: PropTypes.string,
-
-  transform: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-
-  swapOpacity: PropTypes.bool
-}
 
 export default FontAwesomeIcon
 


### PR DESCRIPTION
as I suggested in #232 we can reduce lib bundle size by removing runtime checks of `prop-types` and rely on TypeScript to do build time checks

i really would like to get a feedback on this idea from repo maintainers, so I decided to create PR before getting a green light for it in the issue. I hope its ok and isn't considered PR spam as I didn't intend for it

Anyway thank you for your work regardless if this PR gets approved or cancelled

UPD: as of this article even without bundle size thing `prop-types` are deprecated as of 2017 and its errors will be silently ignored starting from React 19, so more reasons to strip this dep off

https://react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-proptypes-and-defaultprops