### PR TITLE
Update TypeScript to use the React.JSX namespace

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ import {
   FaSymbol
 } from '@fortawesome/fontawesome-svg-core'
 
-export function FontAwesomeIcon(props: FontAwesomeIconProps): JSX.Element
+export function FontAwesomeIcon(props: FontAwesomeIconProps): React.JSX.Element
 
 /**
  * @deprecated use FontAwesomeIconProps


### PR DESCRIPTION
Upstream has deprecated the JSX namespace in favor of React.JSX.