### PR TITLE
Post-3.0.0 Bugfixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,9 @@
         "typescript": "^5.9.2",
         "typescript-eslint": "^8.40.0"
       },
+      "engines": {
+        "node": ">=20"
+      },
       "peerDependencies": {
         "@fortawesome/fontawesome-svg-core": "~6 || ~7",
         "react": "^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -3,10 +3,18 @@
   "description": "Official React component for Font Awesome",
   "version": "3.0.0",
   "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "jsnext:main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    "types": "./dist/index.d.ts",
-    "import": "./dist/index.js",
-    "require": "./dist/index.cjs"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "homepage": "https://github.com/FortAwesome/react-fontawesome",
   "repository": {
@@ -50,6 +58,9 @@
     "install.6": "npm --no-save install @fortawesome/fontawesome-svg-core@6.x @fortawesome/free-solid-svg-icons@6.x",
     "install.7": "npm --no-save install @fortawesome/fontawesome-svg-core@7.x @fortawesome/free-solid-svg-icons@7.x",
     "clean": "rimraf dist"
+  },
+  "engines": {
+    "node": ">=20"
   },
   "dependencies": {
     "semver": "^7.7.2"


### PR DESCRIPTION
As 3.0.0 starts to be adopted by the community, whilst I have taken all due care in testing 3.0.0 in various use cases (plain React, NextJS, Vite), I can guarantee there will be a few teething issues due to being such a large rewrite. 

This PR aims to catch all of the early fixes required from the release of 3.0.0. 