### PR TITLE
fix(browser-support): don't use string.replaceAll to fix safari 12 support

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -78,6 +78,7 @@ const config = tseslint.config(
       // `eslint-plugin-unicorn` rules
       'unicorn/no-keyword-prefix': 'off',
       'unicorn/no-null': 'off',
+      'unicorn/prefer-string-replace-all': 'off', // Since FA still supports Safari 12, which doesn't support String.prototype.replaceAll
       'unicorn/prevent-abbreviations': 'off',
     },
   },

--- a/src/utils/camelize.ts
+++ b/src/utils/camelize.ts
@@ -20,7 +20,7 @@ export function camelize(string: string): string {
     return string
   }
 
-  string = string.replaceAll(/[_-]+(.)?/g, (_: string, chr: string): string => {
+  string = string.replace(/[_-]+(.)?/g, (_: string, chr: string): string => {
     return chr ? chr.toUpperCase() : ''
   })
 

--- a/src/utils/get-class-list-from-props.ts
+++ b/src/utils/get-class-list-from-props.ts
@@ -16,7 +16,7 @@ export function withPrefix(cls: string): string {
     config.cssPrefix || config.familyPrefix || DEFAULT_CLASSNAME_PREFIX
   return prefix === DEFAULT_CLASSNAME_PREFIX
     ? cls
-    : cls.replaceAll(
+    : cls.replace(
         new RegExp(`(?<=^|\\s)${DEFAULT_CLASSNAME_PREFIX}-`, 'g'),
         `${prefix}-`,
       )


### PR DESCRIPTION
Closes #602 